### PR TITLE
[DSSD-50] - Rolling back the last feature (adding durable property).

### DIFF
--- a/Src/Jobbie.Domain/Commands/IJobCreator.cs
+++ b/Src/Jobbie.Domain/Commands/IJobCreator.cs
@@ -11,6 +11,7 @@ namespace Jobbie.Domain.Commands
             string httpVerb,
             string payload,
             string contentType,
+            bool durable,
             string headers);
     }
 }

--- a/Src/Jobbie.Executor/Jobbie.Executor.csproj
+++ b/Src/Jobbie.Executor/Jobbie.Executor.csproj
@@ -61,7 +61,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Jobbie.Domain\Jobbie.Domain.csproj">

--- a/Src/Jobbie.Sample.Client.WebApi.Host/Jobbie.Sample.Client.WebApi.Host.csproj
+++ b/Src/Jobbie.Sample.Client.WebApi.Host/Jobbie.Sample.Client.WebApi.Host.csproj
@@ -132,7 +132,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Jobbie.Infrastructure.Autofac\Jobbie.Infrastructure.Autofac.csproj">

--- a/Src/Jobbie.Sample.Scheduler.Contracts/Api/Payloads/JobCreate.cs
+++ b/Src/Jobbie.Sample.Scheduler.Contracts/Api/Payloads/JobCreate.cs
@@ -16,6 +16,8 @@ namespace Jobbie.Sample.Scheduler.Contracts.Api.Payloads
 
         public string ContentType { get; set; }
 
+        public bool Durable { get; set; }
+
         public string Headers { get; set; }
     }
 }

--- a/Src/Jobbie.Sample.Scheduler.Host/Controllers/JobController.cs
+++ b/Src/Jobbie.Sample.Scheduler.Host/Controllers/JobController.cs
@@ -55,7 +55,7 @@ namespace Jobbie.Sample.Scheduler.Host.Controllers
                 return BadRequest(ModelState);
 
             var jobId = Guid.NewGuid();
-            _creator.Create(jobId, body.Description, body.CallbackUrl, body.HttpVerb, body.Payload, body.ContentType, body.Headers);
+            _creator.Create(jobId, body.Description, body.CallbackUrl, body.HttpVerb, body.Payload, body.ContentType, body.Durable, body.Headers);
             return Get(jobId);
         }
 

--- a/Src/Jobbie.Scheduler.Tests.Unit/Commands/JobCreatorUnitTests.cs
+++ b/Src/Jobbie.Scheduler.Tests.Unit/Commands/JobCreatorUnitTests.cs
@@ -44,6 +44,7 @@ namespace Jobbie.Scheduler.Tests.Unit.Commands
             private readonly string _httpVerb;
             private readonly string _payload;
             private readonly string _contentType;
+            private readonly bool _durable;
             private readonly string _headers;
 
             public TestContext()
@@ -56,6 +57,7 @@ namespace Jobbie.Scheduler.Tests.Unit.Commands
                 _httpVerb = _fixture.Create<string>();
                 _payload = _fixture.Create<string>();
                 _contentType = _fixture.Create<string>();
+                _durable = _fixture.Create<bool>();
                 _headers = _fixture.Create<string>();
 
                 _scheduler = _fixture.Freeze<IScheduler>();
@@ -74,7 +76,7 @@ namespace Jobbie.Scheduler.Tests.Unit.Commands
 
             public TestContext Act()
             {
-                _sut.Create(_jobId, _description, _callbackUrl, _httpVerb, _payload, _contentType, _headers);
+                _sut.Create(_jobId, _description, _callbackUrl, _httpVerb, _payload, _contentType, _durable, _headers);
                 return this;
             }
 
@@ -93,6 +95,7 @@ namespace Jobbie.Scheduler.Tests.Unit.Commands
                                     && j.JobDataMap.GetString("ContentType") == _contentType
                                     && j.JobDataMap.GetLong("CreatedUtc") == _now.Utc.Ticks
                                     && j.JobDataMap.GetString("Headers") == _headers
+                                    && j.Durable == _durable
                                     && !j.RequestsRecovery),
                             Arg<bool>.Is.Equal(true)));
         }

--- a/Src/Jobbie.Scheduler/Commands/JobCreator.cs
+++ b/Src/Jobbie.Scheduler/Commands/JobCreator.cs
@@ -30,6 +30,7 @@ namespace Jobbie.Scheduler.Commands
             string httpVerb,
             string payload,
             string contentType,
+            bool durable,
             string headers)
         {
             _log.Info($"[JobId={jobId}] [MessageText=Creating job (Description={description}).]");
@@ -41,7 +42,7 @@ namespace Jobbie.Scheduler.Commands
                         .Create<JobExecutor>()
                         .WithIdentity(jobId.ToString())
                         .WithDescription(description)
-                        .StoreDurably(true)
+                        .StoreDurably(durable)
                         .UsingJobData("CallbackUrl", callbackUrl)
                         .UsingJobData("HttpVerb", httpVerb)
                         .UsingJobData("Payload", payload)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.{build}
+version: 2.0.{build}
 image: Visual Studio 2017
 pull_requests:
   do_not_increment_build_number: true


### PR DESCRIPTION
Quartz.NET does not allow a job to be created without a trigger.